### PR TITLE
For compilation always replace variable names

### DIFF
--- a/src/model_kit/symengine.jl
+++ b/src/model_kit/symengine.jl
@@ -1,5 +1,3 @@
-export Expression, Variable
-
 using SymEngine_jll: libsymengine
 
 function __init__()


### PR DESCRIPTION
With this, only the structure of the equations and the order of the  variables is important, not their names.
This is in particular handy for `@unique_var` since this doesn't trigger  extensive recompilation.